### PR TITLE
Potential fix for code scanning alert no. 18: Missing cross-site request forgery token validation

### DIFF
--- a/Web/AutoOglasi.Web/Controllers/PostsController.cs
+++ b/Web/AutoOglasi.Web/Controllers/PostsController.cs
@@ -56,6 +56,7 @@ namespace AutoOglasi.Web.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         [Authorize]
         public async Task<IActionResult> Create(PostFormInputModel input)
         {


### PR DESCRIPTION
Potential fix for [https://github.com/RRaleBG/AutoOglasi/security/code-scanning/18](https://github.com/RRaleBG/AutoOglasi/security/code-scanning/18)

Add CSRF token validation to the POST `Create` action in `Web/AutoOglasi.Web/Controllers/PostsController.cs` by applying the `[ValidateAntiForgeryToken]` attribute directly above the method (alongside `[HttpPost]` and `[Authorize]`).

Best single fix without changing functionality:
- In the POST `Create(PostFormInputModel input)` action region (lines ~58–60), insert `[ValidateAntiForgeryToken]` between `[HttpPost]` and `[Authorize]` (or adjacent to them).
- No new imports are required because `Microsoft.AspNetCore.Mvc` is already present and contains `ValidateAntiForgeryTokenAttribute`.

This preserves existing behavior while enforcing anti-forgery token checks for the state-changing POST.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
