### PR TITLE
Potential fix for code scanning alert no. 14: Missing cross-site request forgery token validation

### DIFF
--- a/Web/AutoOglasi.Web/Controllers/PostsController.cs
+++ b/Web/AutoOglasi.Web/Controllers/PostsController.cs
@@ -314,6 +314,7 @@ namespace AutoOglasi.Web.Controllers
 
         [HttpPost]
         [Authorize]
+        [ValidateAntiForgeryToken]
         [ActionName("Delete")]
         public async Task<IActionResult> DeleteConfirmed(int id)
         {


### PR DESCRIPTION
Potential fix for [https://github.com/RRaleBG/AutoOglasi/security/code-scanning/14](https://github.com/RRaleBG/AutoOglasi/security/code-scanning/14)

Add anti-forgery validation to the POST delete action.

Best fix (without changing behavior): in `Web/AutoOglasi.Web/Controllers/PostsController.cs`, add `[ValidateAntiForgeryToken]` directly on `DeleteConfirmed` (between existing attributes is fine). No new imports are needed because `Microsoft.AspNetCore.Mvc` is already present and contains `ValidateAntiForgeryTokenAttribute`.

This keeps the same route/action name and authorization logic, while ensuring requests must include a valid anti-forgery token.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
