### PR TITLE
Potential fix for code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/Web/AutoOglasi.Web/wwwroot/js/owlcarousel/src/js/owl.lazyload.js
+++ b/Web/AutoOglasi.Web/wwwroot/js/owlcarousel/src/js/owl.lazyload.js
@@ -86,6 +86,36 @@
 	};
 
 	/**
+	 * Sanitizes URL values read from DOM attributes before assigning to DOM sinks.
+	 * @param {String} url - Candidate URL.
+	 * @returns {String|null} Sanitized URL or null if unsafe/invalid.
+	 * @protected
+	 */
+	Lazy.prototype._sanitizeUrl = function(url) {
+		if (typeof url !== 'string') {
+			return null;
+		}
+
+		url = $.trim(url);
+
+		if (!url) {
+			return null;
+		}
+
+		// Disallow dangerous schemes explicitly.
+		if (/^(?:javascript|vbscript):/i.test(url)) {
+			return null;
+		}
+
+		// Allow common safe URL forms used by Owl lazy loading.
+		if (/^(?:https?:)?\/\//i.test(url) || /^\//.test(url) || /^[^:?#\s][^?#\s]*$/.test(url)) {
+			return url;
+		}
+
+		return null;
+	};
+
+	/**
 	 * Loads all resources of an item at the specified position.
 	 * @param {Number} position - The absolute position of the item.
 	 * @protected
@@ -101,6 +131,11 @@
 		$elements.each($.proxy(function(index, element) {
 			var $element = $(element), image,
                 url = (window.devicePixelRatio > 1 && $element.attr('data-src-retina')) || $element.attr('data-src') || $element.attr('data-srcset');
+
+			url = this._sanitizeUrl(url);
+			if (!url) {
+				return;
+			}
 
 			this._core.trigger('load', { element: $element, url: url }, 'lazy');
 


### PR DESCRIPTION
Potential fix for [https://github.com/RRaleBG/AutoOglasi/security/code-scanning/7](https://github.com/RRaleBG/AutoOglasi/security/code-scanning/7)

Use strict URL validation/sanitization before any DOM assignment.  
Best fix here: add a helper in `owl.lazyload.js` that accepts only safe URL forms (for example `http:`, `https:`, protocol-relative `//`, root-relative `/`, and simple relative paths), and rejects dangerous schemes such as `javascript:`/`vbscript:` and malformed values. Then sanitize `url` immediately after reading from attributes; if invalid, skip loading that element.

Concretely in `Web/AutoOglasi.Web/wwwroot/js/owlcarousel/src/js/owl.lazyload.js`:
- Add a private helper method `Lazy.prototype._sanitizeUrl`.
- In `Lazy.prototype.load`, after computing `url`, call sanitizer and early-return for invalid values.
- Keep existing lazy-loading behavior unchanged for valid URLs.

No new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
