### PR TITLE
Potential fix for code scanning alert no. 12: Unsafe jQuery plugin

### DIFF
--- a/Web/AutoOglasi.Web/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/Web/AutoOglasi.Web/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -684,7 +684,16 @@ $.extend( $.validator, {
 		},
 
 		clean: function( selector ) {
-			return $( selector )[ 0 ];
+			if ( selector && selector.nodeType ) {
+				return selector;
+			}
+			if ( selector && selector.jquery ) {
+				return selector[ 0 ];
+			}
+			if ( typeof selector === "string" ) {
+				return $.find( selector, this.currentForm )[ 0 ];
+			}
+			return undefined;
 		},
 
 		errors: function() {
@@ -1065,6 +1074,9 @@ $.extend( $.validator, {
 			}
 
 			// Always apply ignore filter
+			if ( typeof element === "string" ) {
+				return $( $.find( element, this.currentForm ) ).not( this.settings.ignore )[ 0 ];
+			}
 			return $( element ).not( this.settings.ignore )[ 0 ];
 		},
 


### PR DESCRIPTION
Potential fix for [https://github.com/RRaleBG/AutoOglasi/security/code-scanning/12](https://github.com/RRaleBG/AutoOglasi/security/code-scanning/12)

The safest fix is to avoid passing potentially string-typed values into `$()` where selector/HTML overloading exists, and instead use APIs that strictly treat input as selectors or return element input unchanged.

Best single fix in the shown code:
1. Harden `clean(selector)` so it:
   - returns DOM/jQuery inputs directly as before,
   - for string input, resolves via `$.find(selector, this.currentForm)` (CSS selector only, no HTML parsing),
   - falls back safely to `undefined` for unsupported types.
2. Harden `validationTargetFor(element)` so it:
   - does not call `$( element )` on string values,
   - if a string somehow arrives, resolves it with `$.find(element, this.currentForm)` and then applies ignore filtering,
   - otherwise preserves existing behavior for DOM/jQuery objects.

This addresses both reported variants (`$.fn.validate` and `$.fn.rules`) by removing unsafe constructor usage in the shared sink path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
